### PR TITLE
fix(app): disable screen blurring during initial biometric auth for now

### DIFF
--- a/app/src/app/(modal)/auth.tsx
+++ b/app/src/app/(modal)/auth.tsx
@@ -1,6 +1,6 @@
 import { FingerprintIcon } from '@theme/icons';
 import { createStyles, useStyles } from '@theme/styles';
-import { ComponentType, Fragment, PropsWithChildren, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Text } from 'react-native-paper';
 import { Subject } from 'rxjs';
@@ -69,7 +69,7 @@ function AuthenticateScreen({ onAuth = emitOnAuth }: AuthenticateScreenProps) {
   });
 
   if (!available) return null;
-  if (!show) return <Blur />;
+  if (!show) return null; // <Blur />; TODO: re-enable once fixed - https://github.com/Kureev/react-native-blur/issues/595
 
   return (
     <Blur>

--- a/app/src/components/Blur/index.native.tsx
+++ b/app/src/components/Blur/index.native.tsx
@@ -1,17 +1,20 @@
 import { useTheme } from 'react-native-paper';
 import { StyleSheet } from 'react-native';
-import { BlurView, BlurViewProps } from '@react-native-community/blur';
+import { BlurView } from '@react-native-community/blur';
 import { StatusBar } from 'expo-status-bar';
+import type { BlurProps } from './index';
 
-export const Blur = ({ children, ...props }: Partial<BlurViewProps>) => (
-  <>
-    <StatusBar style="light" />
-    <BlurView
-      blurAmount={16}
-      blurType={useTheme().dark ? 'light' : 'dark'}
-      style={StyleSheet.absoluteFill}
-      {...props}
-    />
-    {children}
-  </>
-);
+export function Blur({ children, ...props }: BlurProps) {
+  return (
+    <>
+      <StatusBar style="light" />
+      <BlurView
+        blurAmount={16}
+        blurType={useTheme().dark ? 'light' : 'dark'}
+        style={StyleSheet.absoluteFill}
+        {...props}
+      />
+      {children}
+    </>
+  );
+}

--- a/app/src/components/Blur/index.tsx
+++ b/app/src/components/Blur/index.tsx
@@ -10,11 +10,11 @@ const BACKGROUND_COLOR = {
   transparent: 'transparent',
 };
 
-export interface BlurProps extends Omit<BlurViewProps, 'blurType'> {
+export interface BlurProps extends Partial<Omit<BlurViewProps, 'blurType'>> {
   blurType?: 'dark' | 'light';
 }
 
-export const Blur = ({ children, ...props }: Partial<BlurProps>) => {
+export const Blur = ({ children, ...props }: BlurProps) => {
   const styles = useMemoApply(getStyles, {
     blurType: useTheme().dark ? 'light' : 'dark',
     ...props,

--- a/app/src/components/provider/AuthGate.tsx
+++ b/app/src/components/provider/AuthGate.tsx
@@ -3,7 +3,6 @@ import { DateTime, Duration } from 'luxon';
 import { AppState } from 'react-native';
 import { lockSecureStorage, unlockSecureStorage } from '~/lib/secure-storage';
 import AuthenticateScreen from '~/app/(modal)/auth';
-import { Blur } from '#/Blur';
 import { useAuthRequiredOnOpen } from '#/shared/AuthSettings';
 
 const TIMEOUT_AFTER = Duration.fromObject({ minutes: 5 }).toMillis();
@@ -17,7 +16,7 @@ export interface AuthGateProps {
   children: ReactNode;
 }
 
-export const AuthGate = ({ children }: AuthGateProps) => {
+export function AuthGate({ children }: AuthGateProps) {
   const required = useAuthRequiredOnOpen();
 
   const [state, setState] = useState<AuthState>({ success: !required });
@@ -56,4 +55,4 @@ export const AuthGate = ({ children }: AuthGateProps) => {
       {!state.success && <AuthenticateScreen onAuth={onAuth} />}
     </>
   );
-};
+}


### PR DESCRIPTION
This will be re-enabled once the BlurView react-navigation transitioning issue is fixed on Android